### PR TITLE
Make handlePacket() run from esp_yield()

### DIFF
--- a/src/utility/lwIPeth.h
+++ b/src/utility/lwIPeth.h
@@ -124,7 +124,7 @@ boolean LwipEthernet<RawEthernet>::begin (const uint8_t* macAddress, uint16_t mt
 
     if (_intrPin >= 0)
         attachInterrupt(_intrPin, [&]() { this->handlePackets(); }, FALLING);
-    else if (!schedule_function_us([&]() { this->handlePackets(); return true; }, 100))
+    else if (!schedule_function_us([&]() { this->handlePackets(); return true; }, 100, SCHEDULED_FUNCTION_WITHOUT_YIELDELAYCALLS))
     {
         netif_remove(&_netif);
         return false;


### PR DESCRIPTION
Mark handlePacket() function callback as SCHEDULED_FUNCTION_WITHOUT_YIELDELAYCALLS to run it from esp_yield/yield.
It looks safe as definitely no yield or delay calls inside handlePacket() and dipper.
This commit is required to seamless library integration to Arduino core.